### PR TITLE
fix: add pre-flight check for existing files and normalize target path

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -155,6 +155,51 @@ function Get-FrontendDocumentationFile {
     }
 }
 
+function Test-ExistingFiles {
+    $existing = @()
+
+    Get-ChildItem (Join-Path $AgentsSrcDir '*.md') | ForEach-Object {
+        $dst = Join-Path $TargetAgentsDir $_.Name
+        if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+    }
+
+    Get-ChildItem (Join-Path $InstructionsSrcDir '*.md') | ForEach-Object {
+        $dst = Join-Path $TargetInstructionsDir $_.Name
+        if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+    }
+
+    Get-ChildItem (Join-Path $TargetGuidelinesDir '*.md') -ErrorAction SilentlyContinue | ForEach-Object {
+        if (Test-Path $_.FullName -PathType Leaf) { $existing += $_.FullName }
+    }
+
+    if ($DeployOpenCode) {
+        Get-ChildItem (Join-Path $AgentsSrcDir '*.md') | ForEach-Object {
+            $agentName = $_.BaseName -replace '\.agent', ''
+            $dst = Join-Path $TargetPath '.opencode' 'skills' $agentName 'SKILL.md'
+            if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+        }
+        $dst = Join-Path $TargetPath 'AGENTS.md'
+        if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+    }
+
+    if ($DeployClaude) {
+        Get-ChildItem (Join-Path $AgentsSrcDir '*.md') | ForEach-Object {
+            $agentName = $_.BaseName -replace '\.agent', ''
+            $dst = Join-Path $TargetPath '.claude' 'skills' $agentName 'SKILL.md'
+            if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+        }
+        $dst = Join-Path $TargetPath 'CLAUDE.md'
+        if (Test-Path $dst -PathType Leaf) { $existing += $dst }
+    }
+
+    if ($existing.Count -gt 0) {
+        Write-Host "Error: the following files already exist and would be overwritten:" -ForegroundColor Red
+        $existing | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+        Write-Host "Aborting. Remove or rename these files and re-run." -ForegroundColor Red
+        exit 1
+    }
+}
+
 function Copy-RequiredFile {
     param(
         [string]$Src,
@@ -193,6 +238,8 @@ $includeConventions = Read-Host "Include git conventions template as .github/gui
 if ([string]::IsNullOrWhiteSpace($includeConventions)) {
     $includeConventions = 'Y'
 }
+
+Test-ExistingFiles
 
 Write-Host ""
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -59,6 +59,7 @@ done
 DEFAULT_TARGET_PATH="${REPO_ROOT}/target"
 read -r -p "Target path [${DEFAULT_TARGET_PATH}]: " TARGET_PATH_INPUT
 TARGET_PATH="${TARGET_PATH_INPUT:-${DEFAULT_TARGET_PATH}}"
+TARGET_PATH="${TARGET_PATH%/}"
 
 # 2. Optional add-on tools (Copilot/VS Code is always deployed)
 read -r -p "Also set up OpenCode? [Y/N]: " opencode_input
@@ -157,6 +158,51 @@ echo
 read -r -p "Include git conventions template as .github/guidelines/conventions.md? [Y/N]: " INCLUDE_CONVENTIONS
 INCLUDE_CONVENTIONS="${INCLUDE_CONVENTIONS:-Y}"
 
+check_existing_files() {
+  local existing=()
+
+  for f in "${AGENTS_SRC_DIR}"/*.md; do
+    dst="${TARGET_AGENTS_DIR}/$(basename "$f")"
+    [[ -f "$dst" ]] && existing+=("$dst")
+  done
+
+  for f in "${INSTRUCTIONS_SRC_DIR}"/*.md; do
+    dst="${TARGET_INSTRUCTIONS_DIR}/$(basename "$f")"
+    [[ -f "$dst" ]] && existing+=("$dst")
+  done
+
+  for f in "${TARGET_GUIDELINES_DIR}"/*.md; do
+    [[ -f "$f" ]] && existing+=("$f")
+  done
+
+  if [[ "${DEPLOY_OPENCODE}" == "true" ]]; then
+    for f in "${AGENTS_SRC_DIR}"/*.md; do
+      agent_name=$(basename "$f" .md | sed 's/\.agent//')
+      dst="${TARGET_PATH}/.opencode/skills/${agent_name}/SKILL.md"
+      [[ -f "$dst" ]] && existing+=("$dst")
+    done
+    [[ -f "${TARGET_PATH}/AGENTS.md" ]] && existing+=("${TARGET_PATH}/AGENTS.md")
+  fi
+
+  if [[ "${DEPLOY_CLAUDE}" == "true" ]]; then
+    for f in "${AGENTS_SRC_DIR}"/*.md; do
+      agent_name=$(basename "$f" .md | sed 's/\.agent//')
+      dst="${TARGET_PATH}/.claude/skills/${agent_name}/SKILL.md"
+      [[ -f "$dst" ]] && existing+=("$dst")
+    done
+    [[ -f "${TARGET_PATH}/CLAUDE.md" ]] && existing+=("${TARGET_PATH}/CLAUDE.md")
+  fi
+
+  if [[ ${#existing[@]} -gt 0 ]]; then
+    echo "Error: the following files already exist and would be overwritten:" >&2
+    for f in "${existing[@]}"; do
+      echo "  $f" >&2
+    done
+    echo "Aborting. Remove or rename these files and re-run." >&2
+    exit 1
+  fi
+}
+
 copy_file() {
   local src="$1"
   local dst="$2"
@@ -179,6 +225,8 @@ copy_agents_as_skills() {
     cp "$agent_file" "${skill_dir}/SKILL.md"
   done
 }
+
+check_existing_files
 
 echo
 


### PR DESCRIPTION
Adds check_existing_files (bash) / Test-ExistingFiles (PowerShell) to
  abort early with a clear error if any destination files would be
  overwritten, rather than silently clobbering them. Also strips trailing
  slashes from the user-supplied target path so error messages never show
  double slashes in file paths.