### PR TITLE
Add Dockerfiles and Terraform for GCP Cloud Run deployment

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+__pycache__
+**/__pycache__
+.pytest_cache
+.ruff_cache
+.coverage
+tests
+docs
+*.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+COPY src ./src
+COPY templates ./templates
+
+RUN uv sync --frozen --extra api --no-dev
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+EXPOSE 8080
+
+# Cloud Run injects $PORT; default to 8080 for local `docker run`.
+CMD ["sh", "-c", "uvicorn zenflow.routers.app:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/backend/src/zenflow/routers/app.py
+++ b/backend/src/zenflow/routers/app.py
@@ -19,7 +19,8 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    # TODO: narrow to the deployed frontend origin once its GCP URL is known.
+    allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.git
+*.md
+.env*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:22-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time, so the
+# backend's public URL must be known and passed in before `next build` runs.
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+
+RUN pnpm build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+EXPOSE 8080
+
+# Cloud Run injects $PORT; `next start`'s standalone server.js honors it too.
+CMD ["sh", "-c", "PORT=${PORT:-8080} node server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   async headers() {
     return [
       {

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.tfplan

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:olAQvz+q7YBzOi5knYOVPG43mpbCPcwYjVKEKu6hRGs=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,106 @@
+# Zenflow — GCP deployment (Cloud Run)
+
+Provisions Artifact Registry + two Cloud Run services (frontend, backend) for
+Zenflow. State is local (`terraform.tfstate` in this directory) — fine for a
+solo test deployment; see "Moving to remote state" below when you outgrow that.
+
+## Why this is a multi-step apply
+
+The frontend is a static-exported client app: `NEXT_PUBLIC_API_BASE_URL` gets
+compiled into the JS bundle at `next build` time, not read at container
+runtime. That means the backend's Cloud Run URL must exist *before* you build
+the frontend image. Terraform can't sequence "build a Docker image" as part of
+its graph, so this is a scripted multi-step flow, not a single `apply`.
+
+## Prerequisites
+
+- `gcloud` CLI, authenticated (`gcloud auth login`) with a configured project
+- Docker
+- `gcloud auth configure-docker <region>-docker.pkg.dev`
+
+## One-time setup
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars: set project_id (and region if not us-central1)
+terraform init
+```
+
+## Deploy flow
+
+1. **Create the registry** (backend/frontend images don't exist yet, so target
+   just this):
+
+   ```sh
+   terraform apply -target=google_project_service.apis \
+                    -target=google_artifact_registry_repository.zenflow
+   ```
+
+2. **Build and push the backend image**, then deploy it:
+
+   ```sh
+   REGISTRY=$(terraform output -raw artifact_registry_repository)
+   docker build -t "$REGISTRY/backend:v1" ../backend
+   docker push "$REGISTRY/backend:v1"
+
+   terraform apply -var="backend_image=$REGISTRY/backend:v1" \
+                    -target=google_cloud_run_v2_service.backend \
+                    -target=google_cloud_run_v2_service_iam_member.backend_public
+   ```
+
+3. **Build and push the frontend image**, baking in the backend's URL:
+
+   ```sh
+   BACKEND_URL=$(terraform output -raw backend_url)
+   docker build \
+     --build-arg NEXT_PUBLIC_API_BASE_URL="$BACKEND_URL" \
+     -t "$REGISTRY/frontend:v1" ../frontend
+   docker push "$REGISTRY/frontend:v1"
+   ```
+
+4. **Deploy the frontend** (full apply now that both images/vars are known —
+   put `backend_image` and `frontend_image` in `terraform.tfvars` at this point
+   to avoid retyping `-var` flags):
+
+   ```sh
+   terraform apply -var="backend_image=$REGISTRY/backend:v1" \
+                    -var="frontend_image=$REGISTRY/frontend:v1"
+   ```
+
+5. Open `terraform output frontend_url`.
+
+## Redeploying after a code change
+
+Repeat step 2 or 3 with a new tag (`:v2`, etc.) — Cloud Run image references
+must change for `terraform apply` to roll a new revision.
+
+## Current security posture (intentionally open for testing)
+
+- Both services are public (`allUsers` / `roles/run.invoker`) — no auth in
+  front of either one.
+- Backend CORS (`backend/src/zenflow/routers/app.py`) allows `allow_origins=["*"]`.
+
+Before this goes in front of real users:
+
+- Narrow backend CORS to the actual `frontend_url`.
+- Consider whether the backend needs to be reachable directly from the
+  internet at all, or only from the frontend service (e.g. via
+  `ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` plus a serverless VPC
+  connector, or Cloud Run's built-in service-to-service auth with
+  `roles/run.invoker` scoped to the frontend's service account instead of
+  `allUsers`).
+
+## Moving to remote state
+
+Create a GCS bucket, then add to `versions.tf`:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "your-tfstate-bucket"
+    prefix = "zenflow"
+  }
+}
+```
+
+Run `terraform init -migrate-state` afterward.

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -1,0 +1,14 @@
+locals {
+  required_apis = [
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "apis" {
+  for_each = toset(local.required_apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,0 +1,9 @@
+resource "google_artifact_registry_repository" "zenflow" {
+  depends_on = [google_project_service.apis]
+
+  project       = var.project_id
+  location      = var.region
+  repository_id = "zenflow"
+  format        = "DOCKER"
+  description   = "Container images for the Zenflow frontend and backend."
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,28 @@
+resource "google_cloud_run_v2_service" "backend" {
+  depends_on = [google_project_service.apis]
+
+  name                = "zenflow-backend"
+  project             = var.project_id
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = var.backend_image
+      ports {
+        container_port = 8080
+      }
+    }
+  }
+}
+
+# Testing-phase: open to the public internet with no auth. Tighten this (and
+# the backend's CORS allow_origins) once the frontend URL is finalized.
+resource "google_cloud_run_v2_service_iam_member" "backend_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.backend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/frontend.tf
+++ b/terraform/frontend.tf
@@ -1,0 +1,30 @@
+# Note: NEXT_PUBLIC_API_BASE_URL is NOT set here as a container env var — it's
+# a client component fetch URL, so Next.js inlines it into the JS bundle at
+# `next build` time (see frontend/Dockerfile's build arg). Setting it here
+# would have no effect on the already-built image.
+resource "google_cloud_run_v2_service" "frontend" {
+  depends_on = [google_project_service.apis]
+
+  name                = "zenflow-frontend"
+  project             = var.project_id
+  location            = var.region
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = var.frontend_image
+      ports {
+        container_port = 8080
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "frontend_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.frontend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "artifact_registry_repository" {
+  description = "Docker push target, e.g. <output>/backend:TAG"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.zenflow.repository_id}"
+}
+
+output "backend_url" {
+  description = "Public URL of the deployed backend Cloud Run service."
+  value       = google_cloud_run_v2_service.backend.uri
+}
+
+output "frontend_url" {
+  description = "Public URL of the deployed frontend Cloud Run service."
+  value       = google_cloud_run_v2_service.frontend.uri
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+project_id = "your-gcp-project-id"
+region     = "us-central1"
+
+# Fill these in after building/pushing each image (see README.md) — leave
+# blank for the very first apply, which only creates the Artifact Registry.
+# backend_image  = "us-central1-docker.pkg.dev/your-gcp-project-id/zenflow/backend:v1"
+# frontend_image = "us-central1-docker.pkg.dev/your-gcp-project-id/zenflow/frontend:v1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "project_id" {
+  description = "GCP project ID to deploy into."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for Artifact Registry and Cloud Run."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "backend_image" {
+  description = <<-EOT
+    Full Artifact Registry image reference for the backend, e.g.
+    us-central1-docker.pkg.dev/PROJECT/zenflow/backend:TAG.
+    Build and push it (see README.md) before the first apply that targets
+    google_cloud_run_v2_service.backend. Left blank so the initial apply
+    (Artifact Registry only) doesn't require a value yet.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "frontend_image" {
+  description = <<-EOT
+    Full Artifact Registry image reference for the frontend, e.g.
+    us-central1-docker.pkg.dev/PROJECT/zenflow/frontend:TAG.
+    Must be built with --build-arg NEXT_PUBLIC_API_BASE_URL=<backend_url>
+    (see README.md) — that value is compiled into the JS bundle, so this
+    image can only be built after the backend service exists. Left blank so
+    earlier applies don't require a value yet.
+  EOT
+  type        = string
+  default     = ""
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # Local state to start. Migrate to a GCS backend (see README.md) once this
+  # needs to be shared or you want state stored more durably.
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
## Summary
- Add `Dockerfile`s for the frontend (Next.js, standalone output) and backend (FastAPI via uv), both listening on Cloud Run's `$PORT`
- Add Terraform (`terraform/`) provisioning Artifact Registry + two public Cloud Run services (frontend, backend)
- Temporarily open backend CORS (`allow_origins=["*"]`) for testing before the frontend's production URL is known

## Notes
- The frontend image must be built with `--build-arg NEXT_PUBLIC_API_BASE_URL=<backend_url>` since that value is compiled into the client JS bundle at build time, not read at container runtime — this makes deployment a multi-step flow, documented in `terraform/README.md`.
- Terraform state is local for now; `terraform/README.md` covers migrating to a GCS backend later.
- No secrets are committed — `terraform.tfvars` (real project ID) is gitignored; only `terraform.tfvars.example` with placeholders is tracked.
- Before going live: narrow CORS to the real frontend URL and reconsider whether the backend needs public ingress at all (see "Current security posture" in `terraform/README.md`).

## Test plan
- [ ] `terraform init` / `terraform validate` (already run locally, passes)
- [ ] Build and push both images to Artifact Registry per `terraform/README.md`
- [ ] Deploy backend, then frontend with the backend URL baked in
- [ ] Confirm frontend loads and can call the backend end-to-end
- [ ] Tighten CORS and re-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)