### PR TITLE
Fix frontend hydration blocked by strict CSP

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,40 +1,15 @@
 import type { NextConfig } from "next";
 
-const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
-
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob:",
-  "font-src 'self' data:",
-  `connect-src 'self' ${apiBaseUrl}`,
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-].join("; ");
-
-const securityHeaders = [
-  { key: "Content-Security-Policy", value: contentSecurityPolicy },
-  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
-  { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "X-Frame-Options", value: "DENY" },
-  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
-  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
-  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
-];
-
 const nextConfig: NextConfig = {
   output: "standalone",
-  async headers() {
-    return [
-      {
-        source: "/:path*",
-        headers: securityHeaders,
-      },
-    ];
+  // Next's file tracer resolves @swc/helpers dynamically inside require-hook.js,
+  // so it misses the esm/* files that end up needed at runtime — force-include
+  // the whole package. See node_modules/next/dist/docs/.../output.md.
+  outputFileTracingIncludes: {
+    "/*": ["./node_modules/@swc/helpers/**/*"],
   },
+  // Security headers (including a per-request CSP nonce) are set in proxy.ts —
+  // a nonce can't be generated from next.config's static headers().
 };
 
 export default nextConfig;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Manrope } from "next/font/google";
+import { connection } from "next/server";
 import "./globals.css";
 
 const manrope = Manrope({
@@ -13,7 +14,11 @@ export const metadata: Metadata = {
   description: "Generate agent skills for your AI assistant.",
 };
 
-export default function RootLayout({ children }: LayoutProps<"/">) {
+export default async function RootLayout({ children }: LayoutProps<"/">) {
+  // Forces dynamic rendering so proxy.ts's per-request CSP nonce can reach
+  // the inline scripts Next injects — see content-security-policy.md.
+  await connection();
+
   return (
     <html lang="en" className={`${manrope.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col">{children}</body>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// CSP needs a fresh nonce per request, so it's set here (not in next.config.ts
+// headers()) and the page tree is forced into dynamic rendering (see
+// `await connection()` in app/layout.tsx) so Next can inject it.
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const isDev = process.env.NODE_ENV === "development";
+
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""};
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: blob:;
+    font-src 'self' data:;
+    connect-src 'self' ${apiBaseUrl};
+    frame-ancestors 'none';
+    base-uri 'self';
+    form-action 'self';
+  `
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", cspHeader);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  response.headers.set("Content-Security-Policy", cspHeader);
+  response.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  response.headers.set("Cross-Origin-Resource-Policy", "same-origin");
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- The CSP added in a previous commit (`script-src 'self'`, no nonce/`'unsafe-inline'`) silently blocked the inline `<script>` tags Next.js injects to stream hydration data (`self.__next_f.push(...)`). Client JS never mounted, so `useEffect` never ran and the stack picker was stuck on "Loading stacks…" forever, both locally and on the deployed Cloud Run frontend.
- Moves CSP generation into `frontend/src/proxy.ts` so each request gets a fresh nonce (`script-src 'self' 'nonce-...' 'strict-dynamic'`), and forces the root layout into dynamic rendering (`await connection()` in `app/layout.tsx`) so Next.js can thread that nonce through to the inline scripts it injects. `next.config.ts`'s static `headers()` (which can't generate a per-request nonce) is removed in favor of this.
- Confirmed via Cloud Run logs that this is a distinct, real bug — not the earlier `@swc/helpers` tracing fix or the arm64/amd64 image issue from the same debugging session.

## Test plan
- [x] `pnpm build` — route now correctly reports `ƒ (Dynamic)` instead of `○ (Static)`, and `ƒ Proxy (Middleware)` is picked up
- [x] Local standalone build (with static assets + backend reachable) — page hydrates, `/stacks` fetch fires, picker renders `Python — FastAPI`, `Java — Spring Boot`, `Go — Gin`, `TypeScript — Next.js`
- [x] Verified live on the deployed Cloud Run frontend after building/pushing a new image and `terraform apply` — CSP header carries a fresh nonce per request, no console errors, stack picker renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)