### PR TITLE
Clarify skill-mode column headers

### DIFF
--- a/frontend/src/components/CategoryCard.tsx
+++ b/frontend/src/components/CategoryCard.tsx
@@ -54,8 +54,8 @@ export function CategoryCard({ category, expanded, selections, onToggleExpand, o
           >
             <div>Agent</div>
             <div className="text-center">None</div>
-            <div className="text-center">Skill</div>
-            <div className="text-center leading-tight">Custom agent</div>
+            <div className="text-center">SKILL.md file</div>
+            <div className="text-center leading-tight">Custom agent file</div>
           </div>
           {category.skills.map((skill) => (
             <SkillRow


### PR DESCRIPTION
## Summary
- Renames the "Skill" and "Custom agent" column headers in the category card's skill-mode table to "SKILL.md file" and "Custom agent file", making explicit which generated file each mode corresponds to.

## Test plan
- [ ] Visual check: expand a category in the UI and confirm the header row reads "Agent / None / SKILL.md file / Custom agent file"

🤖 Generated with [Claude Code](https://claude.com/claude-code)